### PR TITLE
Add homepage to ios podspec file

### DIFF
--- a/ios/RNUserAgent.podspec
+++ b/ios/RNUserAgent.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNUserAgent
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/bebnev/react-native-user-agent/"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
Adding the library to Podfile manually, breaks while installation because `homepage` variable is not specified