### PR TITLE
fix(android): Use root project build sdk version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,6 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 
 buildscript {
     repositories {
@@ -12,15 +15,16 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion safeExtGet('compileSdkVersion', 27)
+    buildToolsVersion safeExtGet('buildToolsVersion', '27.0.3')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 22)
         versionCode 1
         versionName "1.0"
     }
+
     lintOptions {
         abortOnError false
     }
@@ -33,4 +37,3 @@ repositories {
 dependencies {
     compile 'com.facebook.react:react-native:+'
 }
-  


### PR DESCRIPTION
https://github.com/bebnev/react-native-user-agent/issues/20

Explicitly setting these build values causes incompatible SDKs versions to fail with `Execution failed for task ':react-native-user-agent:verifyReleaseResources'.`

Fixes #20