### PR TITLE
RNUserAgentModule getConstants: use applicationName for userAgent

### DIFF
--- a/android/src/main/java/com/bebnev/RNUserAgentModule.java
+++ b/android/src/main/java/com/bebnev/RNUserAgentModule.java
@@ -81,7 +81,7 @@ public class RNUserAgentModule extends ReactContextBaseJavaModule {
             applicationName = getReactApplicationContext().getApplicationInfo().loadLabel(getReactApplicationContext().getPackageManager()).toString();
             applicationVersion = getPackageInfo().versionName;
             buildNumber = Integer.toString(getPackageInfo().versionCode);
-            userAgent = shortPackageName + '/' + applicationVersion + '.' + buildNumber.toString() + ' ' + this.getUserAgent();
+            userAgent = applicationName + '/' + applicationVersion + '.' + buildNumber.toString() + ' ' + this.getUserAgent();
         } catch(Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
My package name was like "com.example.projectname.dev" (a separate prefix for the Dev environment), so the previous method of getting the name was giving the application name as "dev", it was like: "dev/0.1.1 Mozilla/5.0 (Linux; Android...".

I suggest to use applicationName for this.