### PR TITLE
Fix for RN 0.82

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     def buildGradleVersion = ext.has('buildGradlePluginVersion') ? ext.get('buildGradlePluginVersion') : '3.5.3'
 


### PR DESCRIPTION
After the upgrade to gradle 9 in recent react native, the previously deprecated `jcenter()` method is no longer available. This PR fixes the build issue in RN 0.82 by switching to `mavenCentral()` instead